### PR TITLE
[FEAT] 회원가입 플로우 개선 및 사용자 정보 확장

### DIFF
--- a/jejuday/build.gradle
+++ b/jejuday/build.gradle
@@ -29,10 +29,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //mysql
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // firebase
     implementation 'com.google.firebase:firebase-admin:9.1.1'

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/config/SecurityConfig.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // Public routes
                         .requestMatchers(
+                                "/",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/ws/**",
@@ -82,8 +83,10 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(List.of(
                 "http://localhost:8080",
-                "http://localhost:5173"
-        ));
+                "http://localhost:5173",
+                "http://3.37.245.108:8080",
+                "https://3.37.245.108:8080"
+                ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/controller/AuthController.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/controller/AuthController.java
@@ -85,7 +85,7 @@ public class AuthController {
             String email = userDetails.getUsername();
             User user = userRepository.findByEmail(email)
                     .orElseThrow(() -> new IllegalArgumentException("User not found"));
-            userService.logoutUser(user.getId());
+            userService.logoutUser(user.getId(), response);
         }
 
         return ResponseEntity.ok(ApiResponse.onSuccess("로그아웃 성공"));

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/controller/KakaoController.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/controller/KakaoController.java
@@ -102,7 +102,8 @@ public class KakaoController {
                 kakaoDTO.getProfileImageUrl(),
                 Set.copyOf(request.getThemes()),
                 request.getGender(),
-                Language.KOREAN
+                Language.KOREAN,
+                request.getBirthYear()
         );
 
         User newUser = userService.getUserByEmail(kakaoDTO.getAccountEmail());

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/controller/KakaoController.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/controller/KakaoController.java
@@ -70,7 +70,7 @@ public class KakaoController {
             User user = userService.getUserByEmailOrNull(email);
 
             if (user != null && user.isKakaoLogin()) {
-                userService.logoutUser(user.getId()); // FCM 토큰 제거
+                userService.logoutUser(user.getId(), response); // FCM 토큰 제거
             }
         }
 

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/controller/ProfileController.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/controller/ProfileController.java
@@ -60,4 +60,9 @@ public class ProfileController {
         String imageUrl = userService.getProfileImageUrl(userId);
         return new ResponseEntity<>(ApiResponse.onSuccess(imageUrl), HttpStatus.OK);
     }
+
+    @GetMapping("/healthcheck")
+    public String healthcheck() {
+        return "OK";
+    }
 }

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/controller/RegisterController.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/controller/RegisterController.java
@@ -117,7 +117,8 @@ public class RegisterController {
                 request.getNickname(),
                 profileImageUrl,
                 themes,
-                gender
+                gender,
+                request.getBirthYear()
         );
 
         userService.setLoginCookie(response, request.getEmail());

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/dto/login/response/LoginResponse.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/dto/login/response/LoginResponse.java
@@ -20,6 +20,7 @@ public class LoginResponse {
     private String nickname;
     private String profile;
     private List<String> themes;
+    private String birthYear;
 
     private Language language;
     private Platform platform;

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/dto/register/request/FinalAppRegisterRequest.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/dto/register/request/FinalAppRegisterRequest.java
@@ -3,6 +3,7 @@ package com.goodda.jejuday.auth.dto.register.request;
 import com.goodda.jejuday.common.annotation.valid.ValidNickname;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,4 +29,8 @@ public class FinalAppRegisterRequest {
     private List<String> themes;
 
     private String profile;
+
+    @NotBlank(message = "출생연도는 필수입니다.")
+    @Pattern(regexp = "^(19[0-9]{2}|20[0-2][0-9])$", message = "1900~2029 사이의 연도를 입력해주세요")
+    private String birthYear;
 }

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/dto/register/request/KakaoFinalRegisterRequest.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/dto/register/request/KakaoFinalRegisterRequest.java
@@ -1,6 +1,8 @@
 package com.goodda.jejuday.auth.dto.register.request;
 
 import com.goodda.jejuday.auth.entity.Gender;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,5 +14,9 @@ public class KakaoFinalRegisterRequest {
     private String nickname;
     private List<String> themes;
     private Gender gender;
+
+    @NotBlank(message = "출생연도는 필수입니다.")
+    @Pattern(regexp = "^(19[0-9]{2}|20[0-2][0-9])$", message = "1900~2029 사이의 연도를 입력해주세요")
+    private String birthYear;
 }
 

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/dto/register/response/FinalAppRegisterResponse.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/dto/register/response/FinalAppRegisterResponse.java
@@ -18,6 +18,7 @@ public class FinalAppRegisterResponse {
     private String email;
     private String nickname;
     private List<String> themes;
+    private String birthYear;
     private String message;
     private Gender gender;
 }

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/entity/User.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/entity/User.java
@@ -63,6 +63,9 @@ public class User {
     @Column(name = "password", length = 255)
     private String password;
 
+    @Column(name = "birth_Year", length = 4, nullable = false)
+    private String birthYear;
+
     @Column(name = "nickname", length = 20, nullable = false, unique = true)
     private String nickname;
 

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/repository/EmailVerificationRepository.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/repository/EmailVerificationRepository.java
@@ -13,6 +13,8 @@ public interface EmailVerificationRepository extends JpaRepository<EmailVerifica
     Optional<EmailVerification> findTopByTemporaryUserAndIsVerifiedFalseOrderByCreatedAtDesc(
             TemporaryUser temporaryUser);   //  아직 인증되지 않은 코드 조회
 
+    Optional<EmailVerification> findTopByTemporaryUserAndIsVerifiedTrueOrderByCreatedAtDesc(
+            TemporaryUser temporaryUser);
     void deleteByTemporaryUser_TemporaryUserId(Long temporaryUserId);   //  인증 실패 누적 후 삭제
 
     void deleteByTemporaryUser_Email(String email); //  회원가입 취소 또는 만료 시 삭제

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/security/CookieUtil.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/security/CookieUtil.java
@@ -25,7 +25,7 @@ public class CookieUtil {
                 .secure(secure)
                 .path("/")
                 .sameSite("None")
-                .maxAge(1000 * 60 * 60 * 48) // 2일
+                .maxAge(172800) // 2일
                 .build();
 
         response.addHeader("Set-Cookie", cookie.toString());

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/service/EmailVerificationService.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/service/EmailVerificationService.java
@@ -15,4 +15,6 @@ public interface EmailVerificationService {
     boolean verifyTemporaryUserCode(String email, String code);
 
     boolean verifyUserCode(String email, String code);
+
+    boolean isTemporaryUserVerified(String email);
 }

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/service/KakaoService.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/service/KakaoService.java
@@ -179,7 +179,7 @@ public class KakaoService {
 
     @Transactional
     public void registerKakaoUser(String email, String nickname, String profileUrl,
-                                  Set<String> themeNames, Gender gender, Language language) {
+                                  Set<String> themeNames, Gender gender, Language language, String birthYear) {
 
         if (userRepository.existsByNickname(nickname)) {
             throw new BadRequestException("이미 사용 중인 닉네임입니다.");
@@ -200,6 +200,7 @@ public class KakaoService {
                 .platform(Platform.KAKAO)
                 .language(language)
                 .gender(gender)
+                .birthYear(birthYear)
                 .profile(profileUrl)
                 .userThemes(userThemes)
                 .createdAt(LocalDateTime.now())

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/service/UserService.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/service/UserService.java
@@ -52,7 +52,7 @@ public interface UserService {
 
     void updateNotificationSetting(Long userId, boolean enabled);
 
-    void logoutUser(Long userId);
+    void logoutUser(Long userId, HttpServletResponse response);
 
     void updateNickname(Long userId, String newNickname);
 

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/service/UserService.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/service/UserService.java
@@ -33,15 +33,18 @@ public interface UserService {
 
     void saveTemporaryUser(String name, String email, String password, Platform platform, Language language);
 
-    void completeFinalRegistration(String email, String nickname, String profile, Set<String> themeNames, Gender gender);
+    void completeFinalRegistration(String email, String nickname, String profile, Set<String> themeNames, Gender gender,
+                                   String birthYear);
 
-    void completeRegistration(String email, String nickname, String profile, Set<UserTheme> userThemes, Gender gender);
+    void completeRegistration(String email, String nickname, String profile, Set<UserTheme> userThemes, Gender gender,
+                              String birthYear);
 
     void deleteUsers(String email);
 
     void updateUserLanguage(Long userId, Language language);
 
     boolean existsByEmail(String email);
+
     boolean existsByNickname(String nickname);
 
     Long getAuthenticatedUserId();

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/service/impl/EmailVerificationServiceImpl.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/service/impl/EmailVerificationServiceImpl.java
@@ -93,4 +93,13 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
         emailVerificationRepository.delete(verification);
         return true;
     }
+
+    @Override
+    public boolean isTemporaryUserVerified(String email) {
+        TemporaryUser temporaryUser = temporaryUserRepository.findByEmail(email)
+                .orElseThrow(() -> new EmailSendingException("임시 사용자가 존재하지 않습니다."));
+
+        return emailVerificationRepository.findTopByTemporaryUserAndIsVerifiedTrueOrderByCreatedAtDesc(temporaryUser)
+                .isPresent();
+    }
 }

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/service/impl/UserServiceImpl.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/service/impl/UserServiceImpl.java
@@ -326,11 +326,12 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public void logoutUser(Long userId) {
+    public void logoutUser(Long userId, HttpServletResponse response) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BadRequestException("User not found"));
 
         user.setFcmToken(null);
+        jwtService.clearAccessTokenCookie(response);
     }
 
     @Override

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/service/impl/UserServiceImpl.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/service/impl/UserServiceImpl.java
@@ -17,6 +17,7 @@ import com.goodda.jejuday.auth.repository.TemporaryUserRepository;
 import com.goodda.jejuday.auth.repository.UserRepository;
 import com.goodda.jejuday.auth.repository.UserThemeRepository;
 import com.goodda.jejuday.auth.security.JwtService;
+import com.goodda.jejuday.auth.service.EmailVerificationService;
 import com.goodda.jejuday.auth.service.TemporaryUserService;
 import com.goodda.jejuday.auth.service.UserService;
 import com.goodda.jejuday.auth.util.exception.BadRequestException;
@@ -51,6 +52,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final TemporaryUserRepository temporaryUserRepository;
+    private final EmailVerificationService emailVerificationService;
     private final EmailVerificationRepository emailVerificationRepository;
     private final UserThemeRepository userThemeRepository;
 
@@ -212,6 +214,9 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public void completeFinalRegistration(String email, String nickname, String profile, Set<String> themeNames,
                                           Gender gender, String birthYear) {
+        if (!emailVerificationService.isTemporaryUserVerified(email)) {
+            throw new BadRequestException("이메일 인증이 완료되지 않았습니다.");
+        }
 
         if (userRepository.existsByNickname(nickname)) {
             throw new BadRequestException("이미 사용 중인 닉네임 입니다!");

--- a/jejuday/src/main/java/com/goodda/jejuday/auth/service/impl/UserServiceImpl.java
+++ b/jejuday/src/main/java/com/goodda/jejuday/auth/service/impl/UserServiceImpl.java
@@ -92,6 +92,7 @@ public class UserServiceImpl implements UserService {
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .profile(user.getProfile())
+                .birthYear(user.getBirthYear())
                 .language(user.getLanguage())
                 .platform(user.getPlatform())
                 .themes(user.getUserThemes().stream()
@@ -210,7 +211,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void completeFinalRegistration(String email, String nickname, String profile, Set<String> themeNames,
-                                          Gender gender) {
+                                          Gender gender, String birthYear) {
 
         if (userRepository.existsByNickname(nickname)) {
             throw new BadRequestException("이미 사용 중인 닉네임 입니다!");
@@ -223,14 +224,14 @@ public class UserServiceImpl implements UserService {
                 .collect(Collectors.toSet())
                 : Set.of();
 
-        completeRegistration(email, nickname, profile, userThemes, gender);
+        completeRegistration(email, nickname, profile, userThemes, gender, birthYear);
     }
 
 
     @Override
     @Transactional
     public void completeRegistration(String email, String nickname, String profile, Set<UserTheme> userThemes,
-                                     Gender gender) {
+                                     Gender gender, String birthYear) {
         TemporaryUser tempUser = temporaryUserRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("임시 사용자를 찾을 수 없습니다."));
 
@@ -242,6 +243,7 @@ public class UserServiceImpl implements UserService {
                 .platform(Platform.APP)
                 .language(tempUser.getLanguage())
                 .gender(gender)
+                .birthYear(birthYear)
                 .profile(profile != null ? profile : tempUser.getProfile())
                 .userThemes(userThemes)
                 .createdAt(LocalDateTime.now())

--- a/jejuday/src/main/resources/application.yml
+++ b/jejuday/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/jejuday_db
-    username: ${POSTGRES_USER}
-    password: ${POSTGRES_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://jejuday-db.cd0mk8awog5y.ap-northeast-2.rds.amazonaws.com:3306/mydb
+    username: ${SQL_USER}
+    password: ${SQL_PASSWORD}
     hikari:
       maximum-pool-size: 10
       minimum-idle: 5
@@ -18,7 +18,7 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+        dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
 
   mail:
@@ -55,3 +55,5 @@ kakao:
   redirect:
     url: ${KAKAO_REDIRECT_URL}
 
+server:
+  address: 0.0.0.0

--- a/jejuday/src/test/java/com/goodda/jejuday/auth/service/impl/UserServiceTest.java
+++ b/jejuday/src/test/java/com/goodda/jejuday/auth/service/impl/UserServiceTest.java
@@ -44,10 +44,8 @@ public class UserServiceTest {
     private UserRepository userRepository;
     @Mock
     private TemporaryUserRepository temporaryUserRepository;
-
     @Mock
     private UserThemeRepository userThemeRepository;
-
     @Mock
     private PasswordEncoder passwordEncoder;
     @Mock
@@ -177,7 +175,7 @@ public class UserServiceTest {
         when(temporaryUserRepository.findByEmail("email@test.com")).thenReturn(Optional.of(temp));
         when(userRepository.existsByNickname("nickname")).thenReturn(false);
 
-        userService.completeFinalRegistration("email@test.com", "nickname", "profileUrl", Set.of("산책"), Gender.MALE);
+        userService.completeFinalRegistration("email@test.com", "nickname", "profileUrl", Set.of("산책"), Gender.MALE, "1950");
 
         verify(emailVerificationRepository).deleteByTemporaryUser_TemporaryUserId(1L);
         verify(temporaryUserRepository).delete(temp);


### PR DESCRIPTION
###  새로운 기능
- **JWT 토큰 쿠키 적용**: 기존 세션 기반에서 JWT 토큰 쿠키 방식으로 변경
- **JWT 토큰 자동 재발급**: 토큰 만료 시 자동 갱신 로직 추가
- **사용자 출생연도 필드 추가**: User 엔티티에 birthYear 필드 추가
- **이메일 인증 필수화**: 회원가입 시 이메일 인증 완료 여부 검증 로직 추가

###  수정사항
- 회원가입 관련 DTO에 출생연도 필드 추가
- 로그인/회원가입 응답에 출생연도 정보 포함
- 이메일 인증 서비스에 인증 상태 확인 메서드 추가
- aws RDS 로 변경

###  상세 변경 내용
- `User` 엔티티에 `birthYear` 컬럼 추가
- `FinalAppRegisterRequest`, `LoginResponse` 등 DTO 업데이트
- `EmailVerificationService`에 인증 확인 로직 추가
- JWT 토큰 쿠키 설정 및 재발급 로직 구현